### PR TITLE
v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "aletheia"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "chrono",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aletheia"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "A client library for the Guardian's content API"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -5,22 +5,22 @@
 Aletheia is an HTTP client library for [the Guardian](https://www.theguardian.com)'s [content API](https://open-platform.theguardian.com) written in Rust.
 
 ## How to use it
-Aletheia requires Tokio as a dependency to execute asynchronous code.
+Aletheia requires Tokio as a dependency to execute asynchronous code.\
 Simply add `aletheia` and `tokio` to the list of dependencies in your `Cargo.toml` file.
 
 ```toml
 [dependencies]
-aletheia = "0.1.0"
+aletheia = "0.1.1"
 tokio = { version = "1", features = ["full"] }
 ```
 
-You need an API key to be able to make requests. 
+You also need an API key to be able to make requests. 
 Keys can be requested [here](https://open-platform.theguardian.com/access/). 
 
 ## Example
 
-Let's say you were interested in finding the five most recent film, play or album reviews with a rating of 5 stars 
-containing the word "politics".
+Let's say you were interested in finding five film, play or album reviews with a rating of 5 stars 
+containing the word "politics" published from October to December 2021.
 The code would look something like the example below, and would consist of three steps:
 
 1) Constructing the HTTP client
@@ -41,6 +41,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Query parameters are built incrementally
     let response = client
         .search("politics")
+        .date_from(2021, 10, 1)
+        .date_to(2021, 12, 31)
         .star_rating(5)
         .page_size(5)
         .show_fields(vec![Field::Byline, Field::ShortUrl])

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -358,6 +358,7 @@ impl GuardianContentClient {
     ///         .send()
     ///         .await?;
     /// ```
+    #[allow(clippy::too_many_arguments)] 
     pub fn datetime_from(
         &mut self,
         year: i32,
@@ -407,6 +408,7 @@ impl GuardianContentClient {
     ///         .send()
     ///         .await?;
     /// ```
+    #[allow(clippy::too_many_arguments)]
     pub fn datetime_to(
         &mut self,
         year: i32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -358,7 +358,7 @@ impl GuardianContentClient {
     ///         .send()
     ///         .await?;
     /// ```
-    #[allow(clippy::too_many_arguments)] 
+    #[allow(clippy::too_many_arguments)]
     pub fn datetime_from(
         &mut self,
         year: i32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //! <https://open-platform.theguardian.com/documentation/>
 //!
 //! # Example
-//! ```
+//! ```ignore
 //! use std::error::Error;
 //! use aletheia::GuardianContentClient;
 //! use aletheia::enums::{Field, OrderBy, OrderDate};
@@ -74,7 +74,7 @@ impl GuardianContentClient {
     /// <https://open-platform.theguardian.com/access/>
     ///
     /// # Example
-    /// ```
+    /// ```ignore
     /// let mut client = aletheia::GuardianContentClient("api-key-here");
     /// ```
     pub fn new(api_key: &str) -> GuardianContentClient {
@@ -90,7 +90,7 @@ impl GuardianContentClient {
     fn add_api_key_to_headers(&self) -> HeaderMap {
         let mut headers = HeaderMap::new();
         if !self.api_key.is_empty() {
-            headers.insert("api-key", HeaderValue::from_str(&self.api_key[..]).unwrap());
+            headers.insert("api-key", HeaderValue::from_str(&self.api_key).unwrap());
         }
         headers
     }
@@ -110,7 +110,7 @@ impl GuardianContentClient {
     /// The item endpoint matches the paths on theguardian.com.
     ///
     /// # Example 1
-    /// ```
+    /// ```ignore
     /// let response = client
     ///         .endpoint(Endpoint::Tags)
     ///         .search("food")
@@ -119,7 +119,7 @@ impl GuardianContentClient {
     /// ```
     ///
     /// # Example 2
-    /// ```
+    /// ```ignore
     /// let response = client
     ///         .endpoint(Endpoint::SingleItem)
     ///         .search("books/2022/jan/01/2022-in-books-highlights-for-the-year-ahead")
@@ -150,7 +150,7 @@ impl GuardianContentClient {
     /// have no effect.
     ///
     /// # Example
-    /// ```
+    /// ```ignore
     /// let response = client
     ///         .search("Elections")
     ///         .send()
@@ -168,7 +168,7 @@ impl GuardianContentClient {
     /// as a parameter to this function.
     ///
     /// # Example
-    /// ```
+    /// ```ignore
     /// let response = client
     ///         .search("Elections")
     ///         .page(10)
@@ -188,7 +188,7 @@ impl GuardianContentClient {
     /// The page value must be between 0 and 200 for a successful response.
     ///
     /// # Example
-    /// ```
+    /// ```ignore
     /// let response = client
     ///         .search("Elections")
     ///         .page_size(20)
@@ -209,7 +209,7 @@ impl GuardianContentClient {
     /// - `OrderBy::Relevance`
     ///
     /// # Example
-    /// ```
+    /// ```ignore
     /// let response = client
     ///         .search("Elections")
     ///         .order_by(OrderBy::Oldest)
@@ -230,13 +230,13 @@ impl GuardianContentClient {
     /// - `OrderDate::LastModified`
     ///
     /// # Example
-    /// ```
+    /// ```ignore
     /// let response = client
     ///         .search("Elections")
     ///         .order_by(OrderDate::NewspaperEdition)
     ///         .send()
     ///         .await?;
-    /// ```
+    /// ```ignore
     pub fn order_date(&mut self, order_date: enums::OrderDate) -> &mut GuardianContentClient {
         self.request
             .insert(String::from("order-date"), order_date.to_string());
@@ -258,7 +258,7 @@ impl GuardianContentClient {
     /// or check the `aletheia::enums` section of the documentation.
     ///
     /// # Example
-    /// ```
+    /// ```ignore
     /// let response = client
     ///         .search("Elections")
     ///         .show_fields(vec![Field::StarRating, Field::ShortUrl])
@@ -287,7 +287,7 @@ impl GuardianContentClient {
     /// or check the `aletheia::enums` section of the documentation.
     ///
     /// # Example
-    /// ```
+    /// ```ignore
     /// let response = client
     ///         .search("Elections")
     ///         .show_tags(vec![Tag::Contributor, Tag::Type, Tag::Tone])
@@ -313,7 +313,7 @@ impl GuardianContentClient {
     /// or check the `aletheia::enums` section of the documentation.
     ///
     /// # Example
-    /// ```
+    /// ```ignore
     /// let response = client
     ///         .search("Elections")
     ///         .query_fields(vec![Field::Body])
@@ -330,7 +330,7 @@ impl GuardianContentClient {
     /// Return only content published on or after that date.
     ///
     /// # Example
-    /// ```
+    /// ```ignore
     /// let response = client
     ///         .search("Elections")
     ///         .date_from(2020, 1, 1)
@@ -351,7 +351,7 @@ impl GuardianContentClient {
     /// hours, minutes, seconds as well as a timezone offset.
     ///
     /// # Example
-    /// ```
+    /// ```ignore
     /// let response = client
     ///         .search("Elections")
     ///         .datetime_from(2020, 1, 1, 12, 0, 0, 2)
@@ -378,7 +378,7 @@ impl GuardianContentClient {
     /// Return only content published on or before that date.
     ///
     /// # Example
-    /// ```
+    /// ```ignore
     /// let response = client
     ///         .search("Elections")
     ///         .date_from(2008, 1, 1)
@@ -400,7 +400,7 @@ impl GuardianContentClient {
     /// hours, minutes, seconds as well as a timezone offset.
     ///
     /// # Example
-    /// ```
+    /// ```ignore
     /// let response = client
     ///         .search("Elections")
     ///         .datetime_to(2016, 1, 1, 12, 0, 0, 5)
@@ -434,7 +434,7 @@ impl GuardianContentClient {
     /// - `UseDate::LastModified`
     ///
     /// # Example
-    /// ```
+    /// ```ignore
     /// let response = client
     ///         .search("Elections")
     ///         .date_from(2015, 1, 1)
@@ -452,7 +452,7 @@ impl GuardianContentClient {
     /// Add associated metadata section.
     ///
     /// # Example
-    /// ```
+    /// ```ignore
     /// let response = client
     ///         .search("Elections")
     ///         .show_section(true)
@@ -468,7 +468,7 @@ impl GuardianContentClient {
     /// Return only content in those sections.
     ///
     /// # Example
-    /// ```
+    /// ```ignore
     /// let response = client
     ///         .search("Elections")
     ///         .section("football")
@@ -484,7 +484,7 @@ impl GuardianContentClient {
     /// Return only content with those references.
     ///
     /// # Example
-    /// ```
+    /// ```ignore
     /// let response = client
     ///         .search("Elections")
     ///         .reference("isbn/9780718178949")
@@ -500,7 +500,7 @@ impl GuardianContentClient {
     /// Return only content with references of those types.
     ///
     /// # Example
-    /// ```
+    /// ```ignore
     /// let response = client
     ///         .search("Elections")
     ///         .reference_type("isbn")
@@ -516,7 +516,7 @@ impl GuardianContentClient {
     /// Return only content with those tags.
     ///
     /// # Example
-    /// ```
+    /// ```ignore
     /// let response = client
     ///         .search("Elections")
     ///         .tag("technology/apple")
@@ -531,7 +531,7 @@ impl GuardianContentClient {
     /// Return only content with those IDs.
     ///
     /// # Example
-    /// ```
+    /// ```ignore
     /// let response = client
     ///         .search("Elections")
     ///         .ids("world/2022/jan/01/funeral-of-desmond-tutu-takes-place-in-cape-town")
@@ -546,7 +546,7 @@ impl GuardianContentClient {
     /// Return only content from those production offices.
     ///
     /// # Example
-    /// ```
+    /// ```ignore
     /// let response = client
     ///         .search("Elections")
     ///         .production_office("UK")
@@ -565,7 +565,7 @@ impl GuardianContentClient {
     /// Accepts ISO language codes, e.g. en, fr.
     ///
     /// # Example
-    /// ```
+    /// ```ignore
     /// let response = client
     ///         .search("Elections")
     ///         .lang("en")
@@ -581,7 +581,7 @@ impl GuardianContentClient {
     /// ranging from 1 to 5.
     ///
     /// # Example
-    /// ```
+    /// ```ignore
     /// let response = client
     ///         .search("Elections")
     ///         .star_rating(5)
@@ -599,7 +599,7 @@ impl GuardianContentClient {
     /// `aletheia::enums::Endpoint::Tag`
     ///
     /// # Example
-    /// ```
+    /// ```ignore
     /// let response = client
     ///         .endpoint(Endpoint::Tag)
     ///         .search("Elections")
@@ -632,7 +632,7 @@ impl GuardianContentClient {
     /// - `Block::BodyPublishedSince(i64)`  (only blocks since given timestamp)
     ///
     /// # Example
-    /// ```
+    /// ```ignore
     /// let response = client
     ///         .endpoint(Endpoint::Tag)
     ///         .search("Elections")


### PR DESCRIPTION
**Changelog**
- The API key in the `HeaderValue` is now explicitly passed as a string literal instead of a whole string slice.
- Running `cargo test` will no longer attempt to execute documentation tests.
- Running `cargo clippy` will no longer generate warnings for functions with too many arguments.
- Updated README example.