### PR TITLE
v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+
+## [0.1.3] - 2022-04-18
+
+### Added
+- Added `BodyText` to the `Field` enum. This allows the article body to be displayed with no HTMLin the response (credit to @invokermain for spotting the lacking field).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "aletheia"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "chrono",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aletheia"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "A client library for the Guardian's content API"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Simply add `aletheia` and `tokio` to the list of dependencies in your `Cargo.tom
 
 ```toml
 [dependencies]
-aletheia = "0.1.2"
+aletheia = "0.1.3"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -25,7 +25,7 @@ The code would look something like the example below, and would consist of three
 
 1) Constructing the HTTP client
 2) Building the query
-3) Parsing the response
+3) Parsing the response [*](#debug)
 ```rust
 use aletheia::enums::*;
 use aletheia::GuardianContentClient;
@@ -89,4 +89,10 @@ by Peter Bradshaw (https://www.theguardian.com/p/japa7)
 
 "‘Some of art’s most luxurious orgies’ – Poussin and the Dance review" 
 by Jonathan Jones (https://www.theguardian.com/p/j5kkp)
+```
+
+#### Debug
+[*] You can pretty-print the whole output response with the format specifier `#?`:
+```rust
+println!("{:#?}", response);
 ```

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -36,6 +36,7 @@ pub enum Field {
     Headline,
     ShowInRelatedContent,
     Body,
+    BodyText,
     LastModified,
     HasStoryPackage,
     Score,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,7 +236,7 @@ impl GuardianContentClient {
     ///         .order_by(OrderDate::NewspaperEdition)
     ///         .send()
     ///         .await?;
-    /// ```ignore
+    /// ```
     pub fn order_date(&mut self, order_date: enums::OrderDate) -> &mut GuardianContentClient {
         self.request
             .insert(String::from("order-date"), order_date.to_string());

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -42,6 +42,7 @@ pub struct Fields {
     pub trail_text: Option<String>,
     pub headline: Option<String>,
     pub body: Option<String>,
+    pub body_text: Option<String>,
     pub last_modified: Option<chrono::DateTime<Utc>>,
     pub has_story_package: Option<String>,
     pub score: Option<String>,


### PR DESCRIPTION
## [0.1.3] - 2022-04-18

### Added
- Added `BodyText` to the `Field` enum. This allows the article body to be displayed with no HTMLin the response (credit to @invokermain for spotting the lacking field).