### PR TITLE
v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
+## [0.1.5] - 2022-12-24
+
+### Fixed
+- Fixed incorrect documentation examples for the `tag_type` and `show_blocks` functions, as well as a typo in the `datetime_to` documentation.
+
+### Changed
+- `datetime_to` and `datetime_from` can no longer panic when providing invalid values. Instead, the API call will simply ignore these query parameters and not include them in the request.
+- Structs no longer implement the `Serialize` trait.
+- Improved documentation by using implied shortcut reference links.
+- Updated dependencies.
+
+
 ## [0.1.4] - 2022-12-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,17 +4,25 @@ version = 3
 
 [[package]]
 name = "aletheia"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "chrono",
  "reqwest",
  "serde",
  "serde_json",
- "serde_with",
  "strum",
  "strum_macros",
  "thiserror",
  "tokio",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -61,16 +69,28 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
- "libc",
+ "iana-time-zone",
+ "js-sys",
  "num-integer",
  "num-traits",
  "serde",
  "time",
+ "wasm-bindgen",
  "winapi",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
 ]
 
 [[package]]
@@ -90,36 +110,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
-name = "darling"
-version = "0.13.1"
+name = "cxx"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0d720b8683f8dd83c65155f0530560cba68cd2bf395f6513a483caee57ff7f4"
+checksum = "5add3fc1717409d029b20c5b6903fc0c0b02fa6741d820054f4a2efa5e5816fd"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
 ]
 
 [[package]]
-name = "darling_core"
-version = "0.13.1"
+name = "cxx-build"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a340f241d2ceed1deb47ae36c4144b2707ec7dd0b649f894cb39bb595986324"
+checksum = "b4c87959ba14bc6fbc61df77c3fcfe180fc32b93538c4f1031dd802ccb5f2ff0"
 dependencies = [
- "fnv",
- "ident_case",
+ "cc",
+ "codespan-reporting",
+ "once_cell",
  "proc-macro2",
  "quote",
- "strsim",
+ "scratch",
  "syn",
 ]
 
 [[package]]
-name = "darling_macro"
-version = "0.13.1"
+name = "cxxbridge-flags"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c41b3b7352feb3211a0d743dc5700a4e3b60f51bd2b368892d1e0f9a95f44b"
+checksum = "69a3e162fde4e594ed2b07d0f83c6c67b745e7f28ce58c6df5e6b6bef99dfb59"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e7e2adeb6a0d4a282e581096b06e1791532b7d576dcde5ccd9382acf55db8e6"
 dependencies = [
- "darling_core",
+ "proc-macro2",
  "quote",
  "syn",
 ]
@@ -235,18 +264,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -329,10 +355,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "ident_case"
-version = "1.0.1"
+name = "iana-time-zone"
+version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
+]
 
 [[package]]
 name = "idna"
@@ -347,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.7.0"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -399,9 +443,18 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.112"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "lock_api"
@@ -613,18 +666,18 @@ checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.14"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -751,6 +804,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "scratch"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
+
+[[package]]
 name = "security-framework"
 version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -775,18 +834,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.132"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9875c23cf305cd1fd7eb77234cbb705f21ea6a72c637a5c6db5fe4b8e7f008"
+checksum = "97fed41fc1a24994d044e6db6935e69511a1153b52c15eb42493b26fa87feba0"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.132"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc0db5cb2556c0e558887d9bbdcf6ac4471e83ff66cf696e5419024d1606276"
+checksum = "255abe9a125a985c05190d687b320c12f9b1f0b99445e608c21ba0782c719ad8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -795,9 +854,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.73"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcbd0344bc6533bc7ec56df11d42fb70f1b912351c0825ccb7211b59d8af7cf5"
+checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
@@ -814,29 +873,6 @@ dependencies = [
  "itoa 0.4.8",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_with"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad6056b4cb69b6e43e3a0f055def223380baecc99da683884f205bf347f7c4b3"
-dependencies = [
- "rustversion",
- "serde",
- "serde_with_macros",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12e47be9471c72889ebafb5e14d5ff930d89ae7a67bbdb5f8abb564f845a927e"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -871,22 +907,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
 name = "strum"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cae14b91c7d11c9a851d3fbc80a963198998c2a64eec840477fa92d8ce9b70bb"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 
 [[package]]
 name = "strum_macros"
-version = "0.23.1"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -897,13 +927,13 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.84"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecb2e6da8ee5eb9a61068762a32fa9619cc591ceb055b3687f4cd4051ec2e06b"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -918,6 +948,15 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1059,6 +1098,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+
+[[package]]
 name = "unicode-normalization"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1068,16 +1113,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.8.0"
+name = "unicode-width"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "url"
@@ -1204,6 +1243,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aletheia"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "A client library for the Guardian's content API"
 license = "MIT"
@@ -13,9 +13,8 @@ categories = ["api-bindings", "parsing", "web-programming::http-client"]
 chrono = { version = "0.4", features = ["serde"] }
 tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.11", features = ["json"] }
-serde = { version = "1.0.132", features = ["derive"] }
-serde_with = { version = "1.11.0", features = ["default"] }
-serde_json = { version = "1.0.73", features = ["raw_value"] }
-strum = "0.23"
-strum_macros = "0.23"
+serde = { version = "1.0.151", features = ["derive"] }
+serde_json = { version = "1.0.91", features = ["raw_value"] }
+strum = "0.24.1"
+strum_macros = "0.24.3"
 thiserror = "1.0.38"

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ https://www.theguardian.com/film/2022/sep/02/bones-and-all-review-luca-guadagnin
 ```rust
 println!("{response:#?}");
 ```
-or by using the `dbg!` macro;
+or by using the `dbg!` macro:
 ```rust
 dbg!(response);
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Simply add `aletheia` and `tokio` to the list of dependencies in your `Cargo.tom
 
 ```toml
 [dependencies]
-aletheia = "0.1.4"
+aletheia = "0.1.5"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -94,4 +94,8 @@ https://www.theguardian.com/film/2022/sep/02/bones-and-all-review-luca-guadagnin
 [*] You can pretty-print the whole output response with the format specifier `#?`:
 ```rust
 println!("{response:#?}");
+```
+or by using the `dbg!` macro;
+```rust
+dbg!(response);
 ```

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1,10 +1,10 @@
 //! Enum types that prevent passing illegal parameters to the
 //! Guardian's content API.
 
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use strum_macros::Display;
 
-#[derive(Display, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Display, Debug, Deserialize, Eq, PartialEq)]
 #[strum(serialize_all = "kebab-case")]
 pub enum OrderBy {
     Newest,
@@ -12,7 +12,7 @@ pub enum OrderBy {
     Relevance,
 }
 
-#[derive(Display, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Display, Debug, Deserialize, Eq, PartialEq)]
 #[strum(serialize_all = "kebab-case")]
 pub enum OrderDate {
     Published,
@@ -20,7 +20,7 @@ pub enum OrderDate {
     LastModified,
 }
 
-#[derive(Display, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Display, Debug, Deserialize, Eq, PartialEq)]
 #[strum(serialize_all = "kebab-case")]
 pub enum UseDate {
     Published,
@@ -29,7 +29,7 @@ pub enum UseDate {
     LastModified,
 }
 
-#[derive(Display, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Display, Debug, Deserialize, Eq, PartialEq)]
 #[strum(serialize_all = "camelCase")]
 pub enum Field {
     TrailText,
@@ -55,10 +55,11 @@ pub enum Field {
     LiveBloggingNow,
     CommentCloseDate,
     StarRating,
+    /// Override all fields
     All,
 }
 
-#[derive(Display, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Display, Debug, Deserialize, Eq, PartialEq)]
 #[strum(serialize_all = "kebab-case")]
 pub enum Tag {
     Blog,
@@ -70,14 +71,16 @@ pub enum Tag {
     Series,
     Tone,
     Type,
+    /// Override all tags
     All,
 }
 
-#[derive(Display, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Display, Debug, Deserialize, Eq, PartialEq)]
 #[strum(serialize_all = "kebab-case")]
 pub enum Block<'a> {
     Main,
     Body,
+    /// Override all block types
     All,
     BodyLatest,
     BodyLatestWith(i32),
@@ -90,7 +93,7 @@ pub enum Block<'a> {
     BodyPublishedSince(i64),
 }
 
-#[derive(Display, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Display, Debug, Deserialize, Eq, PartialEq)]
 #[strum(serialize_all = "kebab-case")]
 pub enum Endpoint {
     Content,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,5 @@
+//! Error variants.
+
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -422,7 +422,6 @@ impl GuardianContentClient {
     ///         .send()
     ///         .await?;
     /// ```
-    ///
     #[allow(clippy::too_many_arguments)]
     pub fn datetime_to(
         &mut self,
@@ -436,8 +435,12 @@ impl GuardianContentClient {
     ) -> &mut GuardianContentClient {
         let formatted_datetime =
             crate::helpers::datetime(year, month, day, hour, min, sec, timezone);
-        self.request
-            .insert(String::from("to-date"), formatted_datetime);
+
+        if !formatted_datetime.is_empty() {
+            self.request
+                .insert(String::from("to-date"), formatted_datetime);
+        }
+
         self
     }
 
@@ -780,11 +783,13 @@ mod helpers {
 
         let offset =
             offset(timezone.abs() * 3600).unwrap_or_else(|| FixedOffset::west_opt(0).unwrap());
-        let LocalResult::Single(date) = offset.with_ymd_and_hms(year, month, day, hour, min, sec) else {
-             return "".to_owned()
-        };
 
-        date.to_rfc3339()
+        if let LocalResult::Single(date) = offset.with_ymd_and_hms(year, month, day, hour, min, sec)
+        {
+            date.to_rfc3339()
+        } else {
+            String::new()
+        }
     }
 
     pub(crate) fn mock_response() -> SearchResponse {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,13 +50,13 @@ use std::string::ToString;
 
 const GUARDIAN_CONTENT_API: &str = "https://content.guardianapis.com";
 
-/// A wrapper around Rust's `core::result::Result<T, E>` which
-/// defaults to `aletheia`'s own `Error` type.
+/// A wrapper around Rust's [`core::result::Result<T, E>`] which
+/// defaults to `aletheia`'s own [`Error`] type.
 pub type Result<T> = core::result::Result<T, crate::Error>;
 
 /// The main asynchronous client used to build requests to send to the Guardian's
 /// content API. This client maintains a private internal asynchronous client
-/// implemented by `reqwest::Client`
+/// implemented by [`reqwest::Client`]
 #[derive(Debug)]
 pub struct GuardianContentClient {
     http_client: reqwest::Client,
@@ -103,14 +103,14 @@ impl GuardianContentClient {
     /// Specify the Guardian API endpoint to target.
     ///
     /// Can be one of:
-    /// - `Endpoint::Content` (default): returns all pieces of content in the API.
-    /// - `Endpoint::Tags`: returns all tags in the API. All Guardian content is manually
+    /// - [`Endpoint::Content`] (default): returns all pieces of content in the API.
+    /// - [`Endpoint::Tags`]: returns all tags in the API. All Guardian content is manually
     /// categorised using these tags, of which there are more than 50,000.
-    /// - `Endpoint::Sections`:  returns all sections in the API.
-    /// - `Endpoint::Editions`: returns all editions in the API. Editions are the different
+    /// - [`Endpoint::Sections`]:  returns all sections in the API.
+    /// - [`Endpoint::Editions`]: returns all editions in the API. Editions are the different
     ///   front pages of the Guardian site (currently, there are editions for the United
     /// Kingdom, the United States and Australia).
-    /// - `Endpoint::SingleItem`: returns all the data for a given single item id.
+    /// - [`Endpoint::SingleItem`]: returns all the data for a given single item id.
     ///  Here the term 'item' refers to either a piece of content, a tag, or a section.
     /// The item endpoint matches the paths on theguardian.com.
     ///
@@ -146,12 +146,12 @@ impl GuardianContentClient {
     ///
     /// This field is only valid for the following endpoints:
     ///
-    /// - `Endpoint::Content` (default endpoint, no need to explicitly set it)
-    /// - `Endpoint::Tags`
-    /// - `Endpoint::Sections`
-    /// - `Endpoint::Editions`
+    /// - [`Endpoint::Content`] (default endpoint, no need to explicitly set it)
+    /// - [`Endpoint::Tags`]
+    /// - [`Endpoint::Sections`]
+    /// - [`Endpoint::Editions`]
     ///
-    /// Calling this method on `Endpoint::SingleItem` will
+    /// Calling this method on [`Endpoint::SingleItem`] will
     /// have no effect.
     ///
     /// # Example
@@ -208,10 +208,10 @@ impl GuardianContentClient {
 
     /// Return results in the specified order.
     ///
-    /// The function only accepts one of three `aletheia::enums` enum values:
-    /// - `OrderBy::Newest`
-    /// - `OrderBy::Oldest`
-    /// - `OrderBy::Relevance`
+    /// The function only accepts one of three [`enums::OrderBy`] variants:
+    /// - [`OrderBy::Newest`]
+    /// - [`OrderBy::Oldest`]
+    /// - [`OrderBy::Relevance`]
     ///
     /// # Example
     /// ```ignore
@@ -229,10 +229,10 @@ impl GuardianContentClient {
 
     /// Change which type of date is used to order the results
     ///
-    /// The function only accepts one of three `aletheia::enums` enum values:
-    /// - `OrderDate::Published`
-    /// - `OrderDate::NewspaperEdition`
-    /// - `OrderDate::LastModified`
+    /// The function only accepts one of three [`enums::OrderDate`] variants:
+    /// - [`OrderDate::Published`]
+    /// - [`OrderDate::NewspaperEdition`]
+    /// - [`OrderDate::LastModified`]
     ///
     /// # Example
     /// ```ignore
@@ -250,17 +250,17 @@ impl GuardianContentClient {
 
     /// Add fields associated with the content.
     ///
-    /// The function accepts a vector of `aletheia::enums` values of type `Field`,
+    /// The function accepts a vector of [`enums::Field`] variants,
     /// e.g.
-    /// - `Field::TrailText`
-    /// - `Field::Body`
-    /// - `Field::Byline`
+    /// - [`Field::TrailText`]
+    /// - [`Field::Body`]
+    /// - [`Field::Byline`]
     ///
-    /// If `Field::All` is included in the vector, it will override all other fields.
+    /// If [`Field::All`] is included in the vector, it will override all other fields.
     ///
     /// See <https://open-platform.theguardian.com/documentation/search>
     /// for more information on all the possible fields,
-    /// or check the `aletheia::enums` section of the documentation.
+    /// or check the [`crate::enums`] section of the documentation.
     ///
     /// # Example
     /// ```ignore
@@ -279,17 +279,17 @@ impl GuardianContentClient {
 
     /// Add associated metadata tags.
     ///
-    /// The function accepts a vector of `aletheia::enums` values of type `Tag`,
+    /// The function accepts a vector of [`enums::Tag`] variants,
     /// e.g.
-    /// - `Tag::Blog`
-    /// - `Tag::Contributor`
-    /// - `Tag::Tone`
+    /// - [`Tag::Blog`]
+    /// - [`Tag::Contributor`]
+    /// - [`Tag::Tone`]
     ///
-    /// If `Tag::All` is included in the vector, it will override all other tags.
+    /// If [`Tag::All`] is included in the vector, it will override all other tags.
     ///
     /// See <https://open-platform.theguardian.com/documentation/search>
     /// for more information on all the possible tags,
-    /// or check the `aletheia::enums` section of the documentation.
+    /// or check the [`crate::enums`] section of the documentation.
     ///
     /// # Example
     /// ```ignore
@@ -307,15 +307,15 @@ impl GuardianContentClient {
 
     /// Specify in which indexed fields query terms should be searched on
     ///
-    /// The function accepts a vector of `aletheia::enums` values of type `Field`,
+    /// The function accepts a vector of [`enums::Field`] variants,
     /// e.g.
-    /// - `Field::TrailText`
-    /// - `Field::Body`
-    /// - `Field::Byline`
+    /// - [`Field::TrailText`]
+    /// - [`Field::Body`]
+    /// - [`Field::Byline`]
     ///
     /// See <https://open-platform.theguardian.com/documentation/search>
     /// for more information on all the possible fields,
-    /// or check the `aletheia::enums` section of the documentation.
+    /// or check the [`crate::enums`] section of the documentation.
     ///
     /// # Example
     /// ```ignore
@@ -332,7 +332,7 @@ impl GuardianContentClient {
         self
     }
 
-    /// Return only content published on or after that date.
+    /// Only return content published on or after the specified date.
     ///
     /// # Example
     /// ```ignore
@@ -350,10 +350,13 @@ impl GuardianContentClient {
         self
     }
 
-    /// Return only content published on or after that date.
+    /// Only return content published on or after the specified date.
     ///
     /// It is more specific than `date_from()` as it accepts
     /// hours, minutes, seconds as well as a timezone offset.
+    ///
+    /// Note: Providing invalid YMD-HMS does not append query parameters
+    /// to the API request.
     ///
     /// # Example
     /// ```ignore
@@ -376,12 +379,15 @@ impl GuardianContentClient {
     ) -> &mut GuardianContentClient {
         let formatted_datetime =
             crate::helpers::datetime(year, month, day, hour, min, sec, timezone);
-        self.request
-            .insert(String::from("from-date"), formatted_datetime);
+
+        if !formatted_datetime.is_empty() {
+            self.request
+                .insert(String::from("from-date"), formatted_datetime);
+        }
         self
     }
 
-    /// Return only content published on or before that date.
+    /// Only return content published on or before the specified date.
     ///
     /// # Example
     /// ```ignore
@@ -400,10 +406,13 @@ impl GuardianContentClient {
         self
     }
 
-    /// Return only content published on or before that date.
+    /// Only return content published on or before the specified date.
     ///
     /// It is more specific than `date_to()` as it accepts
     /// hours, minutes, seconds as well as a timezone offset.
+    ///
+    /// Note: Providing invalid YMD-HMS does not append query parameters
+    /// to the API request.
     ///
     /// # Example
     /// ```ignore
@@ -413,6 +422,7 @@ impl GuardianContentClient {
     ///         .send()
     ///         .await?;
     /// ```
+    ///
     #[allow(clippy::too_many_arguments)]
     pub fn datetime_to(
         &mut self,
@@ -434,11 +444,11 @@ impl GuardianContentClient {
     /// Change which type of date is used to filter the results using `date_from()`,
     /// `datetime_from()`, `date_to()` and `datetime_to()`.
     ///
-    /// The function only accepts one of four `aletheia::enums` of type `UseDate`:
-    /// - `UseDate::Published` (default)
-    /// - `UseDate::FirstPublication`
-    /// - `UseDate::NewspaperEdition`
-    /// - `UseDate::LastModified`
+    /// The function only accepts one of four [`enums::UseDate`] variants:
+    /// - [`UseDate::Published`] (default)
+    /// - [`UseDate::FirstPublication`]
+    /// - [`UseDate::NewspaperEdition`]
+    /// - [`UseDate::LastModified`]
     ///
     /// # Example
     /// ```ignore
@@ -601,9 +611,8 @@ impl GuardianContentClient {
         self
     }
 
-    /// Return only tags of that type.
-    /// Only valid if the endpoint is set to
-    /// `aletheia::enums::Endpoint::Tags`
+    /// Only return tags of the specified type.
+    /// Only valid if the endpoint is set to [`Endpoint::Tags`]
     ///
     /// # Example
     /// ```ignore
@@ -623,20 +632,20 @@ impl GuardianContentClient {
 
     /// Add associated blocks (single block for content, one or more for liveblogs).
     ///
-    /// Supports the following `aletheia::enum` types:
+    /// Supports the following [`enums::Block`] variants:
     ///
-    /// - `Block::Main`
-    /// - `Block::Body`
-    /// - `Block::All`
-    /// - `Block::BodyLatest` (limit defaults to 20)
-    /// - `Block::BodyLatestWith(i32)` (override the limits)
-    /// - `Block::BodyOldest`
-    /// - `Block::BodyOldestWith(i32)`
-    /// - `Block::BodyBlockId(&'a str)` (only the block with that ID)
-    /// - `Block::BodyAroundBlockId(&'a str)` (the specified block and 20 blocks either side of it)
-    /// - `Block::BodyAroundBlockIdWith(&'a str, i32)` (the specified block and n blocks either side of it)
-    /// - `Block::BodyKeyEvents`
-    /// - `Block::BodyPublishedSince(i64)`  (only blocks since given timestamp)
+    /// - [`Block::Main`]
+    /// - [`Block::Body`]
+    /// - [`Block::All`]
+    /// - [`Block::BodyLatest`] (limit defaults to 20)
+    /// - [`Block::BodyLatestWith(i32)`] (override the limits)
+    /// - [`Block::BodyOldest`]
+    /// - [`Block::BodyOldestWith(i32)`]
+    /// - [`Block::BodyBlockId(&'a str)`] (only the block with that ID)
+    /// - [`Block::BodyAroundBlockId(&'a str)`] (the specified block and 20 blocks either side of it)
+    /// - [`Block::BodyAroundBlockIdWith(&'a str, i32)`] (the specified block and n blocks either side of it)
+    /// - [`Block::BodyKeyEvents`]
+    /// - [`Block::BodyPublishedSince(i64)`]  (only blocks since given timestamp)
     ///
     /// # Example
     /// ```ignore
@@ -692,7 +701,7 @@ impl GuardianContentClient {
 mod helpers {
     use crate::enums::Block;
     use crate::SearchResponse;
-    use chrono::{FixedOffset, TimeZone};
+    use chrono::{FixedOffset, LocalResult, TimeZone};
     use std::fmt::Display;
 
     pub(crate) fn std_err(message: &Option<String>, response: &Option<SearchResponse>) {
@@ -763,16 +772,19 @@ mod helpers {
         sec: u32,
         timezone: i32,
     ) -> String {
-        let offset: fn(i32) -> FixedOffset = if timezone >= 0 {
-            FixedOffset::east
+        let offset: fn(i32) -> Option<FixedOffset> = if timezone >= 0 {
+            FixedOffset::east_opt
         } else {
-            FixedOffset::west
+            FixedOffset::west_opt
         };
 
-        offset(timezone.abs() * 3600)
-            .ymd(year, month, day)
-            .and_hms(hour, min, sec)
-            .to_rfc3339()
+        let offset =
+            offset(timezone.abs() * 3600).unwrap_or_else(|| FixedOffset::west_opt(0).unwrap());
+        let LocalResult::Single(date) = offset.with_ymd_and_hms(year, month, day, hour, min, sec) else {
+             return "".to_owned()
+        };
+
+        date.to_rfc3339()
     }
 
     pub(crate) fn mock_response() -> SearchResponse {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -402,7 +402,7 @@ impl GuardianContentClient {
 
     /// Return only content published on or before that date.
     ///
-    /// It is more specific than `datetime_to()` as it accepts
+    /// It is more specific than `date_to()` as it accepts
     /// hours, minutes, seconds as well as a timezone offset.
     ///
     /// # Example
@@ -603,12 +603,12 @@ impl GuardianContentClient {
 
     /// Return only tags of that type.
     /// Only valid if the endpoint is set to
-    /// `aletheia::enums::Endpoint::Tag`
+    /// `aletheia::enums::Endpoint::Tags`
     ///
     /// # Example
     /// ```ignore
     /// let response = client
-    ///         .endpoint(Endpoint::Tag)
+    ///         .endpoint(Endpoint::Tags)
     ///         .search("Elections")
     ///         .tag_type("tv-and-radio/us-television")
     ///         .send()
@@ -641,7 +641,7 @@ impl GuardianContentClient {
     /// # Example
     /// ```ignore
     /// let response = client
-    ///         .endpoint(Endpoint::Tag)
+    ///         .endpoint(Endpoint::Tags)
     ///         .search("Elections")
     ///         .show_blocks(Block::BodyPublishedSince(1556529318000))
     ///         .send()

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -5,19 +5,16 @@
 //! Thrift definitions.
 
 use chrono::Utc;
-use serde::{Deserialize, Serialize};
-use serde_with::skip_serializing_none;
+use serde::Deserialize;
 use std::collections::BTreeMap;
 
-#[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 pub struct Response {
     pub message: Option<String>,
     pub response: Option<SearchResponse>,
 }
 
-#[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SearchResponse {
     pub status: Option<String>,
@@ -33,8 +30,7 @@ pub struct SearchResponse {
     pub content: Option<Content>,
 }
 
-#[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Fields {
     pub byline: Option<String>,
@@ -62,8 +58,7 @@ pub struct Fields {
     pub star_rating: Option<String>,
 }
 
-#[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Tag {
     pub id: String,
@@ -92,8 +87,7 @@ pub struct Tag {
     pub internal_name: Option<String>,
 }
 
-#[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SearchResult {
     pub id: String,
@@ -114,15 +108,13 @@ pub struct SearchResult {
     pub editions: Option<Vec<Edition>>,
 }
 
-#[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 pub struct Reference {
     pub id: String,
     pub r#type: String,
 }
 
-#[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Section {
     pub id: String,
@@ -132,8 +124,7 @@ pub struct Section {
     pub editions: Vec<Edition>,
 }
 
-#[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Edition {
     pub id: String,
@@ -143,8 +134,7 @@ pub struct Edition {
     pub code: String,
 }
 
-#[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Blocks {
     pub main: Option<Block>,
@@ -153,8 +143,7 @@ pub struct Blocks {
     pub requested_body_blocks: Option<BTreeMap<String, Vec<Block>>>,
 }
 
-#[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Block {
     pub id: String,
@@ -171,8 +160,7 @@ pub struct Block {
     pub elements: Vec<BlockElement>,
 }
 
-#[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BlockElement {
     pub r#type: String,
@@ -199,16 +187,14 @@ pub struct BlockElement {
     pub code_type_data: Option<CodeElementFields>,
 }
 
-#[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TextElementFields {
     pub html: Option<String>,
     pub role: Option<String>,
 }
 
-#[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct VideoElementFields {
     pub url: Option<String>,
@@ -233,8 +219,7 @@ pub struct VideoElementFields {
     pub source_domain: Option<String>,
 }
 
-#[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TweetElementFields {
     pub source: Option<String>,
@@ -246,8 +231,7 @@ pub struct TweetElementFields {
     pub source_domain: Option<String>,
 }
 
-#[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ImageElementFields {
     pub caption: Option<String>,
@@ -266,8 +250,7 @@ pub struct ImageElementFields {
     pub role: Option<String>,
 }
 
-#[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AudioElementFields {
     pub html: Option<String>,
@@ -284,8 +267,7 @@ pub struct AudioElementFields {
     pub source_domain: Option<String>,
 }
 
-#[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PullquoteElementFields {
     pub html: Option<String>,
@@ -295,8 +277,7 @@ pub struct PullquoteElementFields {
     pub source_domain: Option<String>,
 }
 
-#[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InteractiveElementFields {
     pub url: Option<String>,
@@ -313,8 +294,7 @@ pub struct InteractiveElementFields {
     pub source_domain: Option<String>,
 }
 
-#[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StandardElementFields {
     pub url: Option<String>,
@@ -332,8 +312,7 @@ pub struct StandardElementFields {
     pub source_domain: Option<String>,
 }
 
-#[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WitnessElementFields {
     pub url: Option<String>,
@@ -365,8 +344,7 @@ pub struct WitnessElementFields {
     pub source_domain: Option<String>,
 }
 
-#[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RichLinkElementFields {
     pub url: Option<String>,
@@ -377,8 +355,7 @@ pub struct RichLinkElementFields {
     pub sponsorship: Option<String>,
 }
 
-#[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MembershipElementFields {
     pub original_url: Option<String>,
@@ -395,8 +372,7 @@ pub struct MembershipElementFields {
     pub role: Option<String>,
 }
 
-#[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EmbedElementFields {
     pub html: Option<String>,
@@ -409,8 +385,7 @@ pub struct EmbedElementFields {
     pub caption: Option<String>,
 }
 
-#[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InstagramElementFields {
     pub original_url: String,
@@ -426,8 +401,7 @@ pub struct InstagramElementFields {
     pub source_domain: Option<String>,
 }
 
-#[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CommentElementFields {
     pub source: Option<String>,
@@ -443,8 +417,7 @@ pub struct CommentElementFields {
     pub role: Option<String>,
 }
 
-#[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct VineElementFields {
     pub original_url: String,
@@ -461,8 +434,7 @@ pub struct VineElementFields {
     pub source_domain: Option<String>,
 }
 
-#[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ContentAtomElementFields {
     pub atom_id: String,
@@ -470,23 +442,20 @@ pub struct ContentAtomElementFields {
     pub role: Option<String>,
 }
 
-#[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EmbedTracking {
     pub tracks: String,
 }
 
-#[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CodeElementFields {
     pub html: String,
     pub language: String,
 }
 
-#[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Asset {
     pub r#type: String,
@@ -495,8 +464,7 @@ pub struct Asset {
     pub type_data: Option<AssetFields>,
 }
 
-#[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AssetFields {
     pub aspect_ratio: Option<String>,
@@ -569,17 +537,16 @@ pub struct AssetFields {
     pub safe_embed_code: Option<bool>,
 }
 
-#[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CapiDateTime {
     pub date_time: i64,
     pub iso8601: String,
 }
 
-#[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
 pub struct BlockAttributes {
     key_event: Option<bool>,
     summary: Option<bool>,
@@ -588,24 +555,22 @@ pub struct BlockAttributes {
     membership_placeholder: Option<MembershipPlaceholder>,
 }
 
-#[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MembershipPlaceholder {
     pub campaign_code: Option<String>,
 }
 
-#[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
 pub struct User {
     email: Option<String>,
     first_name: Option<String>,
     last_name: Option<String>,
 }
 
-#[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Content {
     pub id: String,
@@ -630,8 +595,7 @@ pub struct Content {
     pub pillar_name: Option<String>,
 }
 
-#[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ContentFields {
     pub headline: Option<String>,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -153,6 +153,25 @@ mod tests {
     }
 
     #[test]
+    fn test_datetime_to_2() {
+        let mut client = setup();
+        // Invalid offset
+        client.datetime_to(2021, 12, 31, 0, 0, 0, 999);
+        assert_eq!(
+            client.request.get("to-date").unwrap(),
+            "2021-12-31T00:00:00+00:00"
+        );
+    }
+
+    #[test]
+    fn test_datetime_to_3() {
+        let mut client = setup();
+        // Invalid YMD
+        client.datetime_to(2021, 13, 40, 0, 0, 0, 5);
+        assert_eq!(client.request.get("to-date").unwrap(), "");
+    }
+
+    #[test]
     fn test_use_date() {
         let mut client = setup();
         client.use_date(UseDate::FirstPublication);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -153,7 +153,26 @@ mod tests {
     }
 
     #[test]
-    fn test_datetime_to_2() {
+    fn test_datetime_from_wrong_offset() {
+        let mut client = setup();
+        // Invalid offset
+        client.datetime_from(2021, 12, 31, 0, 0, 0, 1024);
+        assert_eq!(
+            client.request.get("from-date").unwrap(),
+            "2021-12-31T00:00:00+00:00"
+        );
+    }
+
+    #[test]
+    fn test_datetime_from_wrong_ymd_hms() {
+        let mut client = setup();
+        // Invalid YMD
+        client.datetime_from(2021, 13, 40, 0, 999, 0, 5);
+        assert_eq!(client.request.get("from-date"), None);
+    }
+
+    #[test]
+    fn test_datetime_to_wrong_offset() {
         let mut client = setup();
         // Invalid offset
         client.datetime_to(2021, 12, 31, 0, 0, 0, 999);
@@ -164,11 +183,11 @@ mod tests {
     }
 
     #[test]
-    fn test_datetime_to_3() {
+    fn test_datetime_to_wrong_ymd_hms() {
         let mut client = setup();
         // Invalid YMD
-        client.datetime_to(2021, 13, 40, 0, 0, 0, 5);
-        assert_eq!(client.request.get("to-date").unwrap(), "");
+        client.datetime_to(2021, 13, 40, 0, 999, 0, 5);
+        assert_eq!(client.request.get("to-date"), None);
     }
 
     #[test]


### PR DESCRIPTION
## [0.1.5] - 2022-12-24

### Fixed
- Fixed incorrect documentation examples for the `tag_type` and `show_blocks` functions, as well as a typo in the `datetime_to` documentation.

### Changed
- `datetime_to` and `datetime_from` can no longer panic when providing invalid values. Instead, the API call will simply ignore these query parameters and not include them in the request.
- Structs no longer implement the `Serialize` trait.
- Improved documentation by using implied shortcut reference links.
- Updated dependencies.
